### PR TITLE
Fixed a critical bug on Safari

### DIFF
--- a/public/javascripts/app/services/announcementService.js
+++ b/public/javascripts/app/services/announcementService.js
@@ -1,10 +1,10 @@
 PulseApp.factory('$announcementService', ['$socket', '$resource', '$rootScope',
 	 function($socket, $resource, $rootScope){
 	
-	var restService = $resource('/messages/:id', {},{
+	var restService = $resource('/messages/:id', {},{get:{
 			method: 'GET',
 			cache:false
-		});
+		}});
 
 	var lastMsg = '';
 	var announcementService = {


### PR DESCRIPTION
The intent is to override the GET http request to avoid caching, but the syntax is wrong. I don't know why this doesn't cause other browsers to fail, but Safari is mightily displeased. Please Safari please Mark.
