### PR TITLE
Fixed an issue with purgeOldMessages

### DIFF
--- a/server/routes/chat.js
+++ b/server/routes/chat.js
@@ -123,9 +123,10 @@ exports.renameUser = function(req, res){
 	res.send();
 };
 
-function purgeOldMessages(){
-	if(messages.length>100)
-		messages.splice(0, 1);
+function purgeOldMessages() {
+    var numToDelete = messages.length - 100;
+	if(numToDelete>0)
+		messages.splice(0, numToDelete);
 }
 
 


### PR DESCRIPTION
Certain message types aren't calling purgeOldMessages.  Because purge only ever deletes 1 message at a time it leads to the messages array slowly growing and never correcting itself.  The new method ensures the messages will be pruned properly no matter how badly out of sync the message purging gets